### PR TITLE
Update Versions for use with inspector-laravel package in Laravel 9 environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2"
+        "php": ">=7.2|^8.0|^8.1"
     },
     "autoload": {
         "psr-4": {
@@ -23,7 +23,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Added compatibility for PHP 8.0 and PHP 8.1

Update PHPUnit Version to 9.0 - 8.0 is no longer maintained