### PR TITLE
Clean the Configuration class and add more tests

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -6,16 +6,16 @@ namespace Inspector;
 class Configuration
 {
     /**
-     * Remote endpoint to send data.
+     * The remote url to send data.
      *
      * @var string
      */
     protected $url = 'https://ingest.inspector.dev';
 
     /**
-     * Authentication key.
+     * The API key.
      *
-     * @var string
+     * @var string|null
      */
     protected $ingestionKey;
 
@@ -42,14 +42,14 @@ class Configuration
     protected $version = '3.12.2';
 
     /**
-     * Transport options.
+     * General-purpose options, E.g. we can set the transport proxy.
      *
      * @var array
      */
     protected $options = [];
 
     /**
-     * Environment constructor.
+     * Configuration constructor.
      *
      * @param null|string $ingestionKey
      * @throws \InvalidArgumentException
@@ -63,8 +63,6 @@ class Configuration
 
     /**
      * Max size of a POST request content.
-     *
-     * @return  integer
      */
     public function getMaxPostSize(): int
     {
@@ -72,17 +70,22 @@ class Configuration
     }
 
     /**
-     * Set ingestion url.
+     * Set the remote url.
      *
      * @param string $value
-     * @return Configuration
+     * @return $this
+     * @throws \InvalidArgumentException
      */
     public function setUrl($value): Configuration
     {
         $value = \trim($value);
 
         if (empty($value)) {
-            throw new \InvalidArgumentException('Invalid URL');
+            throw new \InvalidArgumentException('URL can not be empty');
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_URL) === false) {
+            throw new \InvalidArgumentException('URL is invalid');
         }
 
         $this->url = $value;
@@ -90,9 +93,7 @@ class Configuration
     }
 
     /**
-     * Get ingestion endpoint.
-     *
-     * @return string
+     * Get the remote url.
      */
     public function getUrl(): string
     {
@@ -102,7 +103,7 @@ class Configuration
     /**
      * Verify if api key is well formed.
      *
-     * @param $value
+     * @param string $value
      * @return $this
      * @throws \InvalidArgumentException
      */
@@ -119,18 +120,13 @@ class Configuration
     }
 
     /**
-     * Get current API key.
-     *
-     * @return string
+     * Get the current API key.
      */
     public function getIngestionKey(): string
     {
         return $this->ingestionKey;
     }
 
-    /**
-     * @return int
-     */
     public function getMaxItems(): int
     {
         return $this->maxItems;
@@ -138,7 +134,7 @@ class Configuration
 
     /**
      * @param int $maxItems
-     * @return Configuration
+     * @return $this
      */
     public function setMaxItems(int $maxItems): Configuration
     {
@@ -146,22 +142,17 @@ class Configuration
         return $this;
     }
 
-    /**
-     * Transport options.
-     *
-     * @return array
-     */
     public function getOptions(): array
     {
         return $this->options;
     }
 
     /**
-     * Add a new entry in the options list.
+     * Add a key-value pair to the options list.
      *
      * @param string $key
-     * @param $value
-     * @return Configuration
+     * @param mixed $value
+     * @return $this
      */
     public function addOption($key, $value): Configuration
     {
@@ -170,7 +161,7 @@ class Configuration
     }
 
     /**
-     * Override the transport options.
+     * Override the entire options.
      *
      * @param array $options
      * @return $this
@@ -183,8 +174,6 @@ class Configuration
 
     /**
      * Check if data transfer is enabled.
-     *
-     * @return bool
      */
     public function isEnabled(): bool
     {
@@ -205,8 +194,6 @@ class Configuration
 
     /**
      * Get current transport method.
-     *
-     * @return string
      */
     public function getTransport(): string
     {
@@ -227,8 +214,6 @@ class Configuration
 
     /**
      * Get the package version.
-     *
-     * @return string
      */
     public function getVersion(): string
     {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -31,22 +31,60 @@ class ConfigurationTest extends TestCase
     {
         $configuration = new Configuration('aaa');
 
-        $this->assertInstanceOf(Configuration::class, $configuration->setIngestionKey('xxx'));
-        $this->assertSame('xxx', $configuration->getIngestionKey());
-
-        $this->assertInstanceOf(Configuration::class, $configuration->setUrl('http://www.example.com'));
+        $this->assertSame($configuration, $configuration->setUrl('http://www.example.com'));
         $this->assertSame('http://www.example.com', $configuration->getUrl());
 
-        $this->assertInstanceOf(Configuration::class, $configuration->setOptions([]));
-        $this->assertSame([], $configuration->getOptions());
+        $this->assertSame($configuration, $configuration->setIngestionKey('xxx'));
+        $this->assertSame('xxx', $configuration->getIngestionKey());
 
-        $this->assertInstanceOf(Configuration::class, $configuration->setEnabled(true));
+        $this->assertSame($configuration, $configuration->setEnabled(true));
         $this->assertSame(true, $configuration->isEnabled());
 
-        $this->assertInstanceOf(Configuration::class, $configuration->setTransport('async'));
-        $this->assertSame('async', $configuration->getTransport());
-
-        $this->assertInstanceOf(Configuration::class, $configuration->setMaxItems(150));
+        $this->assertSame($configuration, $configuration->setMaxItems(150));
         $this->assertSame(150, $configuration->getMaxItems());
+
+        $this->assertSame($configuration, $configuration->setTransport('sync'));
+        $this->assertSame('sync', $configuration->getTransport());
+
+        $this->assertSame($configuration, $configuration->addOption('one', 1));
+        $this->assertSame(['one' => 1], $configuration->getOptions());
+        $this->assertSame($configuration, $configuration->addOption('two', 2));
+        $this->assertSame(['one' => 1, 'two' => 2], $configuration->getOptions());
+        // It override existing keys.
+        $this->assertSame($configuration, $configuration->addOption('one', 'number1'));
+        $this->assertSame(['one' => 'number1', 'two' => 2], $configuration->getOptions());
+
+        $this->assertSame($configuration, $configuration->setOptions([]));
+        $this->assertSame([], $configuration->getOptions());
+    }
+
+    public function testUrlCanNotBeEmpty()
+    {
+        $configuration = new Configuration('aaa');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('URL can not be empty');
+
+        $configuration->setUrl('');
+    }
+
+    public function testUrlMustBeValid()
+    {
+        $configuration = new Configuration();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('URL is invalid');
+
+        $configuration->setUrl('foobar');
+    }
+
+    public function testIngestionKeyCanNotBeEmpty()
+    {
+        $configuration = new Configuration();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Ingestion key cannot be empty');
+
+        $configuration->setIngestionKey('');
     }
 }


### PR DESCRIPTION
In this PR, I've cleaned some doc-block, type-hint and added more tests for the Configuration class:
- Fluent API methods currently return the Configuration itself instead a new one, so we should verify them using `assertSame` instead of `assertInstanceof`
- There are a few missing tests for `setUrl`, `setIngestionKey`, `addOptions` and `setOptions`.
- Because some methods have explicit return types, it isn't necessary to keep `@return` docblock.