### PR TITLE
Add create and configure method to the Inspector class

### DIFF
--- a/src/Inspector.php
+++ b/src/Inspector.php
@@ -44,6 +44,22 @@ class Inspector
     protected static $beforeCallbacks = [];
 
     /**
+     * Create an Inspector instance with a single ingestion key.
+     */
+    public static function create(string $ingestionKey, ?callable $configure = null): static
+    {
+        $configuration = new Configuration($ingestionKey);
+
+        if ($configure) {
+            $configure($configuration);
+        }
+
+        $inspector = new static($configuration);
+
+        return $inspector;
+    }
+
+    /**
      * Inspector constructor.
      *
      * @param Configuration $configuration
@@ -61,6 +77,16 @@ class Inspector
 
         $this->configuration = $configuration;
         \register_shutdown_function(array($this, 'flush'));
+    }
+
+    /**
+     * Change the configuration instance.
+     */
+    public function configure(callable $callback)
+    {
+        $callback($this->configuration, $this);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
I suggest adding these 2 methods to the Inspector class for convenient usage:

### create

This is the most use-case as the it's written in the docs. Instead of creating a `Configuration` instance, then creating an `Inspector` instance, it should be able to create `Inspector` instance with a single key.

```php

use Inspector\Inspector;
use Inspector\Configuration;

// Before
$configuration = new Configuration('example-api-key');
$inspector = new Inspector($configuration);

// After
$inspector = Inspector::create('example-api-key');
```

If users really want to modify configuration on creation, they can pass a callable as the second parameter.

```php
$inspector = Inspector::create('example-api-key', function (Configuration $config) {
    $config->setMaxItems(1000);
    $config->setOptions([
          'proxy' => 'https://proxy-example.com',
    ]);
});
```

### configure

In runtime, instead of replacing the `Configuration` instance, we can allow users to customize it.

```php

$inspector = Inspector::create('example-api-key');

$inspector->startTransaction('inspector:test');

// Logic code...

if ($condition) {
     $inspector->configure(function (Configuration $config) {
          $config->setMaxItems(30);
     }
} else {
     $inspector->configure(function (Configuration $config) {
          $config->setMaxItems(50);
     }
}

// Logic code....
```

```php
Inspector::beforeFlush(function ($inspector) {
    if ($condition) {
        $inspector->configure(function ($config) {
            $config->setOptions([
                'proxy' => 'https://proxy-url-example.com',
            ]);
        });
    }
});
```