### PR TITLE
Set export-ignore for PHP CS Fixer and PHPStan files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,9 @@
 /.github             export-ignore
 /.gitignore          export-ignore
 /.travis.yml         export-ignore
+/.php-cs-fixer.dist.php   export-ignore
 /CODE_OF_CONDUCT.md  export-ignore
 /CONTRIBUTING.md     export-ignore
+/phpstan.neon        export-ignore
 /phpunit.xml.dist    export-ignore
 /tests               export-ignore


### PR DESCRIPTION
We can set export-ignore for `.php-cs-fixer.dist.php` and `phpstan.neon` because they are useless when users install `inspector-apm/inspector-php` via Composer.